### PR TITLE
updating rails backend db schema migrations

### DIFF
--- a/db/migrate/20160228120618_create_stations.rb
+++ b/db/migrate/20160228120618_create_stations.rb
@@ -1,7 +1,6 @@
 class CreateStations < ActiveRecord::Migration
   def change
-    create_table :stations, :id => false do |t|
-      t.column :id, :serial4, primary_key: true
+    create_table :stations do |t|
       t.text :name
       t.text :details
       t.text :location

--- a/db/migrate/20160228120759_create_value_types.rb
+++ b/db/migrate/20160228120759_create_value_types.rb
@@ -4,7 +4,6 @@ class CreateValueTypes < ActiveRecord::Migration
       t.text :name
       t.text :details
       t.text :unit
-
     end
   end
 end

--- a/db/migrate/20160228121523_create_measurements.rb
+++ b/db/migrate/20160228121523_create_measurements.rb
@@ -1,7 +1,7 @@
 class CreateMeasurements < ActiveRecord::Migration
   def change
     create_table :measurements, :id => false do |t|
-      t.column :id, :serial8, primary_key: true
+      t.column :id, :serial8
       t.references :station
       t.references :value_type
       t.timestamp :measured_at

--- a/db/migrate/20160228125249_add_foreign_keys.rb
+++ b/db/migrate/20160228125249_add_foreign_keys.rb
@@ -1,6 +1,6 @@
 class AddForeignKeys < ActiveRecord::Migration
   def change
-    add_foreign_key :measurements, :value_types
-    add_foreign_key :measurements, :stations
+    add_foreign_key :measurements, :value_types, on_update: :cascade
+    add_foreign_key :measurements, :stations, on_update: :cascade
   end
 end

--- a/db/migrate/20160228150513_change_not_null.rb
+++ b/db/migrate/20160228150513_change_not_null.rb
@@ -1,8 +1,5 @@
 class ChangeNotNull < ActiveRecord::Migration
   def change
-    change_column_null :measurements, :station_id, false
-    change_column_null :measurements, :value_type_id, false
-    change_column_null :measurements, :measured_at, false
     change_column_null :measurements, :measured_value, false
     change_column_null :value_types, :name, false
     change_column_null :stations, :name, false

--- a/db/migrate/20160308201419_create_join_table_station_value_type.rb
+++ b/db/migrate/20160308201419_create_join_table_station_value_type.rb
@@ -4,7 +4,7 @@ class CreateJoinTableStationValueType < ActiveRecord::Migration
       t.index [:station_id, :value_type_id]
       t.index [:value_type_id, :station_id]
     end
-    add_foreign_key :stations_value_types, :stations
-    add_foreign_key :stations_value_types, :value_types
+    add_foreign_key :stations_value_types, :stations, on_update: :cascade, on_delete: :cascade
+    add_foreign_key :stations_value_types, :value_types, on_update: :cascade, on_delete: :cascade
   end
 end

--- a/db/migrate/20160317164306_add_multiple_primary_keys.rb
+++ b/db/migrate/20160317164306_add_multiple_primary_keys.rb
@@ -1,0 +1,3 @@
+class AddMultiplePrimaryKeys < ActiveRecord::Migration
+  execute "ALTER TABLE measurements ADD PRIMARY KEY (station_id,value_type_id,measured_at);"
+end


### PR DESCRIPTION
- adding multiple primary key for table measurements (station_id,
  value_type_id, measured_at)
- changing foreign keys to cascade on update for table measurements
- changing foreign keys to cascade on update and on deletion for table
  stations_value_types
